### PR TITLE
Make division have the same behavior as sum and multiplication

### DIFF
--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -27,7 +27,7 @@ func between(operator string, values []interface{}, data interface{}) interface{
 }
 
 func unary(operator string, value interface{}) interface{} {
-	if operator == "+" || operator == "*" {
+	if operator == "+" || operator == "*" || operator == "/" {
 		return toNumber(value)
 	}
 

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -51,6 +51,21 @@ func TestSimpleComparisonWithInteger(t *testing.T) {
 	}
 }
 
+func TestDivWithOnlyOneValue(t *testing.T) {
+	var rules interface{}
+	json.Unmarshal([]byte(`{"/":[4]}`), &rules)
+
+	var result interface{}
+	err := Apply(rules, nil, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if result != float64(4) {
+		t.Fatal("Is expected to return the only value present in the array")
+	}
+}
+
 func TestSimpleComparisonWithString(t *testing.T) {
 	var rules interface{}
 	json.Unmarshal([]byte(`{


### PR DESCRIPTION
The idea of this is to make the division operator `/` have the same behavior as sum `+` and multiplication `*`, allowing the operator to evaluate correctly in cases theres only one value in the input array.