### PR TITLE
Use io.Reader and io.Writer interfaces

### DIFF
--- a/internal/testing.go
+++ b/internal/testing.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"reflect"
+)
+
+type (
+	Test struct {
+		Rule     io.Reader
+		Data     io.Reader
+		Expected io.Reader
+	}
+
+	Tests []Test
+)
+
+func convertInterfaceToReader(i interface{}) io.Reader {
+	var result bytes.Buffer
+
+	encoder := json.NewEncoder(&result)
+	encoder.Encode(i)
+
+	return &result
+
+}
+
+func GetScenariosFromOfficialTestSuite() Tests {
+	var tests Tests
+
+	response, err := http.Get("http://jsonlogic.com/tests.json")
+	if err != nil {
+		log.Fatal(err)
+
+		return tests
+	}
+
+	buffer, _ := ioutil.ReadAll(response.Body)
+
+	response.Body.Close()
+
+	var scenarios []interface{}
+
+	err = json.Unmarshal(buffer, &scenarios)
+	if err != nil {
+		log.Fatal(err)
+
+		return tests
+	}
+
+	for _, scenario := range scenarios {
+		if reflect.ValueOf(scenario).Kind() == reflect.String {
+			continue
+		}
+
+		tests = append(tests, Test{
+			Rule:     convertInterfaceToReader(scenario.([]interface{})[0]),
+			Data:     convertInterfaceToReader(scenario.([]interface{})[1]),
+			Expected: convertInterfaceToReader(scenario.([]interface{})[2]),
+		})
+	}
+
+	return tests
+}

--- a/validator.go
+++ b/validator.go
@@ -1,12 +1,21 @@
 package jsonlogic
 
-// IsValid verifies if the JSON Logic is valid
-func IsValid(rules interface{}) bool {
-	if isPrimitive(rules) || isSlice(rules) || rules == nil {
-		return true
+import (
+	"encoding/json"
+	"io"
+)
+
+// IsValid reads a JSON Logic rule from io.Reader and validates it
+func IsValid(rule io.Reader) bool {
+	var _rule interface{}
+
+	decoderRule := json.NewDecoder(rule)
+	err := decoderRule.Decode(&_rule)
+	if err != nil {
+		return false
 	}
 
-	return validateJsonLogic(rules)
+	return validateJsonLogic(_rule)
 }
 
 func validateJsonLogic(rules interface{}) bool {


### PR DESCRIPTION
This refactor jsonlogic functions to get the logic and data as an io.Reader interface and the result must be an io.Writer interface where the output of the logic execution will be write.

This breaks compatibility with the old signature where the input and output is based on `interface{}`. I do think this BC makes sense and we achieve a better code using those interfaces.