### PR TITLE
fix less operator bad evaluation when args are a mix of string and nu…

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -10,6 +10,10 @@ func less(a, b interface{}) bool {
 		return toNumber(b) > toNumber(a)
 	}
 
+    if isNumber(a) || isNumber(b) {
+		return toNumber(b) > toNumber(a)
+    }
+
 	return toString(b) > toString(a)
 }
 

--- a/comp.go
+++ b/comp.go
@@ -6,7 +6,7 @@ import (
 )
 
 func less(a, b interface{}) bool {
-	if isNumber(a) {
+	if isString(a) != isString(b) {
 		return toNumber(b) > toNumber(a)
 	}
 


### PR DESCRIPTION
Hi,

Ran into the following invalid evaluation :
x Logic :
{ "and" : [
  {">" : [ { "var" : "temp" }, "100" ]} // please note the number-as-string representation
] }
x Data :
{ "temp" : 12 }
x Result : true

The way the comp function deals with arguments returns true because both args are handled as strings ("12" is greater than "100") whereas they should be handled as numbers (based on jsonlogic.com playground).