### PR TITLE
fix less operator bad evaluation when args are a mix of string and nu…

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -6,7 +6,7 @@ import (
 )
 
 func less(a, b interface{}) bool {
-	if isNumber(a) {
+	if isNumber(a) || isNumber(b) {
 		return toNumber(b) > toNumber(a)
 	}
 


### PR DESCRIPTION
Hi,

The following logic failed :

{">" : [12, "100"]}

This should returns true but instead returns false because the way the comp function handles both arguments as string ("12" > "100") . Handling args preferably as number is the goal of this fix.

Regards,