### PR TITLE
Fixing merge recursive

### DIFF
--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -288,16 +288,16 @@ func substr(values interface{}) interface{} {
 	return string(runes[from:to])
 }
 
-func merge(values interface{}) interface{} {
+func merge(values interface{}, level int8) interface{} {
 	result := make([]interface{}, 0)
 
-	if isPrimitive(values) {
+	if isPrimitive(values) || level > 1 {
 		return append(result, values)
 	}
 
 	if isSlice(values) {
 		for _, value := range values.([]interface{}) {
-			_values := merge(value).([]interface{})
+			_values := merge(value, level+1).([]interface{})
 
 			result = append(result, _values...)
 		}
@@ -518,7 +518,7 @@ func operation(operator string, values, data interface{}) interface{} {
 	}
 
 	if operator == "merge" {
-		return merge(values)
+		return merge(values, 0)
 	}
 
 	if operator == "if" {

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/diegoholiveira/jsonlogic/internal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/alexjunioravila/jsonlogic/internal"
 )
 
 func TestRulesFromJsonLogic(t *testing.T) {

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/alexjunioravila/jsonlogic/internal"
+	"github.com/diegoholiveira/jsonlogic/internal"
 )
 
 func TestRulesFromJsonLogic(t *testing.T) {

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -337,3 +337,34 @@ func TestAbsoluteValue(t *testing.T) {
 
 	assert.JSONEq(t, "2", result.String())
 }
+
+func TestMergeArrayOfArrays(t *testing.T) {
+	rule := strings.NewReader(`{
+		"merge": [
+			[
+				[
+					"18800000",
+					"18800969"
+				]
+			],
+			[
+				[
+					"19840000",
+					"19840969"
+				]
+			]
+		]
+	}`)
+	data := strings.NewReader(`{}`)
+
+	expectedResult := "[[\"18800000\",\"18800969\"],[\"19840000\",\"19840969\"]]"
+
+	var result bytes.Buffer
+	err := Apply(rule, data, &result)
+	t.Log(result.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, expectedResult, result.String())
+}

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/diegoholiveira/jsonlogic/internal"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRulesFromJsonLogic(t *testing.T) {
@@ -360,7 +360,6 @@ func TestMergeArrayOfArrays(t *testing.T) {
 
 	var result bytes.Buffer
 	err := Apply(rule, data, &result)
-	t.Log(result.String())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Implementation of [JSON Logic](http://jsonlogic.com) in Go Lang.
 ## What's JSON Logic?
 
 JSON Logic is a DSL to write logic decisions in JSON. It's has a great specification and is very simple to learn.
-The official website has a great documentation with examples: http://jsonlogic.com
+The [official website](http://jsonlogic.com) has a great documentation with examples.
 
 
 ## How to use it


### PR DESCRIPTION
This pull request fixes the merge operation for changing the behavior to same of JsonLogic Playground. In old logic, the library merges all arrays in only one resulted array. This is the expected result when we are merging arrays of primitive types. However,  if we merging one array of arrays (the following example), this behavior is not expected.
``` json
{
  "merge": [
    [
      ["18800000", "18800969"]
    ],
    [
      ["19840000", "19840969"]
    ]
  ]
}
```
The result of merge in old logic is:
```json

["18800000", "18800969", "19840000", "19840969"]
``` 
The result of merge in [JsonLogic Playground](http://jsonlogic.com/play.html):
```json
[
  ["18800000", "18800969"],
  ["19840000", "19840969"]
]
``` 