### PR TITLE
fix empty rules object that should return an empty object instead of false

### DIFF
--- a/internal/testing.go
+++ b/internal/testing.go
@@ -53,6 +53,15 @@ func GetScenariosFromOfficialTestSuite() Tests {
 		return tests
 	}
 
+    // add missing but relevant scenarios
+    var rule []interface{}
+
+    scenarios = append(scenarios,
+        append(rule,
+            make(map[string]interface {}, 0),
+            make(map[string]interface {}, 0),
+            make(map[string]interface {}, 0)))
+
 	for _, scenario := range scenarios {
 		if reflect.ValueOf(scenario).Kind() == reflect.String {
 			continue

--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -708,7 +708,8 @@ func apply(rules, data interface{}) interface{} {
 		return operation(operator, parseValues(values, data), data)
 	}
 
-	return false
+	// an empty-map rule should return an empty-map
+	return make(map[string]interface{})
 }
 
 // Apply read the rule and it's data from io.Reader, executes it


### PR DESCRIPTION
Fix the following bad falsy eval :
=============== >8 ================
rules : {}
data : {}
return : false
=============== 8< ================

As seen in jsonlogic.com playground, a rule defined as an empty object should be evaluated as an empty object instead of a falsy.