### PR TITLE
Fixing nil exception for in operation

### DIFF
--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -161,6 +161,10 @@ func _inSorted(value interface{}, values interface{}) bool {
 }
 
 func _in(value interface{}, values interface{}) bool {
+	if value == nil || values == nil {
+		return false
+	}
+
 	if isString(values) {
 		return strings.Contains(values.(string), value.(string))
 	}

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -539,3 +539,25 @@ func TestUnaryOperation(t *testing.T) {
 
 	assert.JSONEq(t, `true`, result.String())
 }
+
+func TestInOperatorAgainstNil(t *testing.T) {
+	rule := strings.NewReader(`{"filter":[{"var": "accounts"},{"and":[{"in":["abc",{"var":"tags.tag-1"}]}]}]}`)
+	data := strings.NewReader(`{"accounts":[{"name":"account-1","tags":{"tag-1":"abc"}}, {"name":"account-2","tags":{"tag-2":"xyz"}}]}`)
+
+	var result bytes.Buffer
+	err := Apply(rule, data, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `[
+		{
+			"name": "account-1",
+			"tags": {
+				"tag-1": "abc"
+			}
+		}
+	]`
+
+	assert.JSONEq(t, expected, result.String())
+}


### PR DESCRIPTION
rule: `{"filter":[{"var": "accounts"},{"and":[{"in":["abc",{"var":"tags.tag-1"}]}]}]}`
data: `{"accounts":[{"id":"111111111111","name":"account-2","tags":{"tag-1":"abc"},"createdAt":"2021-06-24T11:14:25Z","updatedAt":"2021-06-24T11:14:25Z"},{"id":"111111111117","name":"account-7","tags":{"mytag":"custom"},"createdAt":"2021-06-24T11:14:25Z","updatedAt":"2021-06-24T11:14:25Z"}]}`

playground code that shows the problem: https://play.golang.org/p/vH_npwpjLFM