### PR TITLE
support for primitive object return values

### DIFF
--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -350,8 +350,6 @@ func all(values, data interface{}) interface{} {
 		return false
 	}
 
-	
-
 	for _, value := range subject.([]interface{}) {
 		conditions := solveVars(parsed[1], value)
 		v := apply(conditions, value)
@@ -447,7 +445,15 @@ func parseValues(values, data interface{}) interface{} {
 }
 
 func apply(rules, data interface{}) interface{} {
-	for operator, values := range rules.(map[string]interface{}) {
+	ruleMap := rules.(map[string]interface{})
+
+	// A map with more than 1 key counts as a primitive
+	// end recursion
+	if len(ruleMap) > 1 {
+		return ruleMap
+	}
+
+	for operator, values := range ruleMap {
 		if operator == "filter" {
 			return filter(values, data)
 		}

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -724,3 +724,20 @@ func TestIssue52_example2(t *testing.T) {
 	expected := `"jsonlogic"`
 	assert.JSONEq(t, expected, result.String())
 }
+
+func TestIssue58_example(t *testing.T) {
+	data := strings.NewReader(`{"foo": "bar"}`)
+	logic := strings.NewReader(`{"if":[
+		{"==":[{"var":"foo"},"bar"]},{"foo":"is_bar","path":"foo_is_bar"},
+		{"foo":"not_bar","path":"default_object"}
+	]}`)
+
+	var result bytes.Buffer
+	err := Apply(logic, data, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{"foo":"is_bar","path":"foo_is_bar"}`
+	assert.JSONEq(t, expected, result.String())
+}


### PR DESCRIPTION
Adds an additional check while recursively parsing through a rule map. If the parsed map has more than 1 key, treat it as a primitive and return. This matches logic currently implemented in the javascript `is_logic` check: https://github.com/jwadhams/json-logic-js/blob/9c805e9ac6a3787e8508e982a079888d3cc295b5/logic.js#L180

Resolves #58 