### PR TITLE
Enable Go 1.20 and 1.21 in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15', '1.16', '1.18', '1.19']
+        go: ['1.14', '1.15', '1.16', '1.18', '1.19', '1.20', '1.21']
     name: Running with Go ${{ matrix.go }}
     steps:
     - name: Install Go


### PR DESCRIPTION
Hi @diegoholiveira, me again 👋 

It may be a good idea to enable Go 1.20 and 1.21 in ci as well as I expect there are quite a few people on these versions now. If you would like you could also possibly drop some older versions and bump the Go version of the package as Go only supports the two latest major versions. I don't know if that would impact some of your users though.