### PR TITLE
hydrating the engine

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,41 @@
+package jsonlogic
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func BenchmarkEngine_normal(b *testing.B) {
+	rules := `{"<": [{"var": "temp"}, 110]}`
+
+	for i := 1; i <= 1000; i++ {
+		tempData := fmt.Sprintf(`{"temp": %d}`, i)
+		data := strings.NewReader(tempData)
+
+		var result strings.Builder
+		Apply(strings.NewReader(rules), data, &result)
+	}
+
+}
+
+func BenchmarkEngine_Apply(b *testing.B) {
+
+	engine := NewEngine()
+	rules := `{"<": [{"var": "temp"}, 110]}`
+
+	hash := sha256.Sum256([]byte(rules))
+	hashKey := hex.EncodeToString(hash[:]) // Convert hash to a string
+
+	// Call Build with both ruleKey and hashKey
+	engine.Build(rules, hashKey)
+
+	for i := 1; i <= 1000; i++ {
+		tempData := fmt.Sprintf(`{"temp": %d}`, i)
+		data := strings.NewReader(tempData)
+		var result strings.Builder
+		engine.Apply(strings.NewReader(rules), data, &result)
+	}
+}


### PR DESCRIPTION
To use the `Build` and `Apply` functions from the `Engine` struct in a third-party application, you can follow these steps:

1. **Initialize the Engine**:
   ```go
   import (
       "strings"
       "github.com/diegoholiveira/jsonlogic"
   )

   func main() {
       engine := jsonlogic.NewEngine()
   }
   ```

2. **Build Rules**:
   ```go
   rule_content := `{"<": [{"var": "temp"}, 110]}`
   rule_unique_key := "the truly unique key defined by the client"
   err := engine.Build(rule_content, rule_unique_key)
   if err != nil {
       log.Fatalf("Failed to build rules: %v", err)
   }
   ```

3. **Apply Rules**:
   ```go
   data := strings.NewReader(`{"temp": 100}`)
   var result strings.Builder
   rule_unique_key := "the truly unique key defined by the client"
   err = engine.Apply(rule_unique_key, data, &result)
   if err != nil {
       log.Fatalf("Failed to apply rules: %v", err)
   }
   fmt.Println("Result:", result.String())
   ```

This example demonstrates how to initialize the engine, build rules, and apply those rules to a data set.