### PR TITLE
Enhancement proposal for test names in TestRulesFromJsonLogic test suite

### DIFF
--- a/internal/testing.go
+++ b/internal/testing.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"log"
@@ -15,22 +14,12 @@ type (
 		Rule     any
 		Data     any
 		Expected any
+		Scenario string
+		Index    int
 	}
 
 	Tests []Test
 )
-
-func convertInterfaceToReader(i any) io.Reader {
-	var result bytes.Buffer
-
-	encoder := json.NewEncoder(&result)
-	err := encoder.Encode(i)
-	if err != nil {
-		panic(err)
-	}
-
-	return &result
-}
 
 // This gets the tests.json file that we've proposed become the new official one in
 // https://github.com/jwadhams/json-logic/pull/48 but that hasn't merged yet.
@@ -78,8 +67,12 @@ func getScenariosFromFile(buffer []byte) Tests {
 			make(map[string]any),
 			make(map[string]any)))
 
+	scenarioName := ""
+	testIndex := 0
 	for _, scenario := range scenarios {
 		if reflect.ValueOf(scenario).Kind() == reflect.String {
+			scenarioName = scenario.(string)
+			testIndex = 0
 			continue
 		}
 
@@ -87,7 +80,10 @@ func getScenariosFromFile(buffer []byte) Tests {
 			Rule:     scenario.([]any)[0],
 			Data:     scenario.([]any)[1],
 			Expected: scenario.([]any)[2],
+			Scenario: scenarioName,
+			Index:    testIndex,
 		})
+		testIndex++
 	}
 
 	return tests

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -21,8 +21,8 @@ func TestRulesFromJsonLogic(t *testing.T) {
 
 	for suiteName, tests := range suites {
 		t.Run(suiteName, func(t *testing.T) {
-			for i, test := range tests {
-				t.Run(fmt.Sprintf("Scenario_%d", i), func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(fmt.Sprintf("%s_%d", test.Scenario, test.Index), func(t *testing.T) {
 					result, err := jsonlogic.ApplyInterface(test.Rule, test.Data)
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
This is just a proposal to enhance test names around `TestRulesFromJsonLogic`, to make it clearer for devs which test is failing:

### Before

![Screenshot 2025-03-25 at 2 33 50 PM](https://github.com/user-attachments/assets/21983188-19d6-4a0a-818d-ff9112dc3bbf)

### After

![Screenshot 2025-03-25 at 2 27 01 PM](https://github.com/user-attachments/assets/a1afbd54-b192-447f-8816-aa99c07aed27)