### PR TITLE
fixed logical operators

### DIFF
--- a/logic.go
+++ b/logic.go
@@ -5,57 +5,31 @@ import (
 )
 
 func _and(values, data any) any {
-	values = values.([]any)
-
-	var v float64
-
-	isBoolExpression := true
-
-	for _, value := range values.([]any) {
-		value = parseValues(value, data)
-		if typing.IsSlice(value) {
-			return value
-		}
-
-		if typing.IsBool(value) && !value.(bool) {
-			return false
-		}
-
-		if typing.IsString(value) && typing.ToString(value) == "" {
-			return value
-		}
-
-		if !typing.IsNumber(value) {
-			continue
-		}
-
-		isBoolExpression = false
-
-		_value := typing.ToNumber(value)
-
-		if _value > v {
-			v = _value
+	args := values.([]any)
+	var last any
+	for _, value := range args {
+		parsed := parseValues(value, data)
+		last = parsed
+		if !typing.IsTrue(parsed) {
+			return parsed
 		}
 	}
 
-	if isBoolExpression {
-		return true
-	}
-
-	return v
+	return last
 }
 
 func _or(values, data any) any {
-	values = values.([]any)
-
-	for _, value := range values.([]any) {
+	args := values.([]any)
+	var last any
+	for _, value := range args {
 		parsed := parseValues(value, data)
+		last = parsed
 		if typing.IsTrue(parsed) {
 			return parsed
 		}
 	}
 
-	return false
+	return last
 }
 
 func evaluateClause(clause any, data any) any {

--- a/logic_test.go
+++ b/logic_test.go
@@ -1,0 +1,167 @@
+package jsonlogic_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	jsonlogic "github.com/diegoholiveira/jsonlogic/v3"
+)
+
+func TestAndReturnsFirstFalsyArgument(t *testing.T) {
+	rule := `{"and":["", true, "unused"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `""`, result.String())
+}
+
+func TestAndReturnsFirstFalsyEmptyArray(t *testing.T) {
+	rule := `{"and":[[], 1, "done"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `[]`, result.String())
+}
+
+func TestAndReturnsNullWhenNoArguments(t *testing.T) {
+	rule := `{"and":[]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `null`, result.String())
+}
+
+func TestAndReturnsFirstFalsyNumber(t *testing.T) {
+	rule := `{"and":[0, 2, 3]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `0`, result.String())
+}
+
+func TestAndReturnsLastArgumentWhenAllTruthy(t *testing.T) {
+	rule := `{"and":[true, 1, "done"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `"done"`, result.String())
+}
+
+func TestAndReturnsLastArgumentWhenAllTruthyNoNumbers(t *testing.T) {
+	rule := `{"and":[true, "yes"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `"yes"`, result.String())
+}
+
+func TestAndReturnsFalsyAfterTruthyArray(t *testing.T) {
+	rule := `{"and":[[1], 0, "unused"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `0`, result.String())
+}
+
+func TestOrReturnsFirstTruthyArgument(t *testing.T) {
+	rule := `{"or":["ok", 0, false]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `"ok"`, result.String())
+}
+
+func TestOrReturnsNullWhenNoArguments(t *testing.T) {
+	rule := `{"or":[]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `null`, result.String())
+}
+
+func TestOrReturnsFirstTruthyNumber(t *testing.T) {
+	rule := `{"or":[1, false, "later"]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `1`, result.String())
+}
+
+func TestOrReturnsFirstTruthyArray(t *testing.T) {
+	rule := `{"or":[[1, 2], 0, false]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `[1,2]`, result.String())
+}
+
+func TestOrReturnsLastArgumentWhenAllFalsy(t *testing.T) {
+	rule := `{"or":[0, false, ""]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `""`, result.String())
+}
+
+func TestOrReturnsLastFalsyArrayWhenAllFalsy(t *testing.T) {
+	rule := `{"or":[0, false, []]}`
+
+	var result bytes.Buffer
+	err := jsonlogic.Apply(strings.NewReader(rule), strings.NewReader(`{}`), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.JSONEq(t, `[]`, result.String())
+}


### PR DESCRIPTION
Modified and/or operators so they behave more consistently to the JSONLogic spec:

AND will return the first 'falsy' argument or the last argument
OR will return the first 'truthy' argument or the last argument.

Added test to validate these assumptions.