### PR TITLE
fix: preserve op vals in or/and short circuit

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -406,3 +406,95 @@ func TestIssue125_CustomOperatorWithVarsInSlice(t *testing.T) {
 	expected := `true`
 	assert.JSONEq(t, expected, result.String())
 }
+
+func TestIssue135(t *testing.T) {
+	cases := []struct {
+		name     string
+		rule     string
+		expected string
+	}{
+		{
+			name:     "or returns last operand when all are falsy",
+			rule:     `{"or":[null,0]}`,
+			expected: `0`,
+		},
+		{
+			name:     "and returns last operand when all are truthy",
+			rule:     `{"and":[1,"result"]}`,
+			expected: `"result"`,
+		},
+		{
+			name:     "and returns last truthy operand, not max",
+			rule:     `{"and":[3,1]}`,
+			expected: `1`,
+		},
+		{
+			name:     "and example from jsonlogic.com docs",
+			rule:     `{"and":[true,"a",3]}`,
+			expected: `3`,
+		},
+		{
+			name:     "and returns first falsy operand (empty string)",
+			rule:     `{"and":[true,"",3]}`,
+			expected: `""`,
+		},
+		{
+			name:     "or short-circuits on first truthy operand",
+			rule:     `{"or":[1,0]}`,
+			expected: `1`,
+		},
+		{
+			name:     "and with non-empty slice continues past it",
+			rule:     `{"and":[[1,2,3],true]}`,
+			expected: `true`,
+		},
+		{
+			name:     "and with empty slice returns it",
+			rule:     `{"and":[[],true]}`,
+			expected: `[]`,
+		},
+		{
+			name:     "or returns null when all operands are null",
+			rule:     `{"or":[null,null]}`,
+			expected: `null`,
+		},
+		{
+			name:     "or returns empty array as last falsy operand",
+			rule:     `{"or":[false,[]]}`,
+			expected: `[]`,
+		},
+		{
+			name:     "and with empty operand list returns null",
+			rule:     `{"and":[]}`,
+			expected: `null`,
+		},
+		{
+			name:     "or with empty operand list returns null",
+			rule:     `{"or":[]}`,
+			expected: `null`,
+		},
+		{
+			name:     "or with single falsy operand returns it",
+			rule:     `{"or":[0]}`,
+			expected: `0`,
+		},
+		{
+			name:     "and with single falsy operand returns it",
+			rule:     `{"and":[0]}`,
+			expected: `0`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result bytes.Buffer
+			err := jsonlogic.Apply(strings.NewReader(tc.rule), strings.NewReader(`{}`), &result)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// `or` should return the first truthy operand or the last operand;
+			// `and` should return the first falsy operand or the last operand.
+			assert.JSONEq(t, tc.expected, result.String())
+		})
+	}
+}

--- a/logic.go
+++ b/logic.go
@@ -7,55 +7,29 @@ import (
 func _and(values, data any) any {
 	values = values.([]any)
 
-	var v float64
-
-	isBoolExpression := true
-
+	var last any
 	for _, value := range values.([]any) {
-		value = parseValues(value, data)
-		if typing.IsSlice(value) {
-			return value
-		}
-
-		if typing.IsBool(value) && !value.(bool) {
-			return false
-		}
-
-		if typing.IsString(value) && typing.ToString(value) == "" {
-			return value
-		}
-
-		if !typing.IsNumber(value) {
-			continue
-		}
-
-		isBoolExpression = false
-
-		_value := typing.ToNumber(value)
-
-		if _value > v {
-			v = _value
+		last = parseValues(value, data)
+		if !typing.IsTrue(last) {
+			return last
 		}
 	}
 
-	if isBoolExpression {
-		return true
-	}
-
-	return v
+	return last
 }
 
 func _or(values, data any) any {
 	values = values.([]any)
 
+	var last any
 	for _, value := range values.([]any) {
-		parsed := parseValues(value, data)
-		if typing.IsTrue(parsed) {
-			return parsed
+		last = parseValues(value, data)
+		if typing.IsTrue(last) {
+			return last
 		}
 	}
 
-	return false
+	return last
 }
 
 func evaluateClause(clause any, data any) any {


### PR DESCRIPTION
The PR contains 2 significant changes in the way `or`/`and` work:

* `and`: iterate through operands, return the first falsy operand; if none are falsy, return the last operand
* `or`: iterate through operands, return the first truthy operand; if none are truthy, return the last operand

This seems to me a clearer implementation, and also fixes some buggy edge cases with the current implementation. Some of the implications are subtle, but all are more consistent with the canonical JS impl, and JavaScript idioms.

I've added tests for all such cases.

Fixes: https://github.com/diegoholiveira/jsonlogic/issues/135